### PR TITLE
Add new GLE OnStarted event handler. Remove OnPlayerStartedEvent.

### DIFF
--- a/Runtime/Gamelogic/VisualScriptingEventNames.cs
+++ b/Runtime/Gamelogic/VisualScriptingEventNames.cs
@@ -18,7 +18,7 @@ namespace VisualPinball.Unity
 {
 	public static class VisualScriptingEventNames
 	{
-		public const string PlayerStartedEvent = "PlayerStartedEvent";
+		public const string GleStartedEvent = "GleStartedEvent";
 		public const string LampEvent = "LampEvent";
 		public const string SwitchEvent = "SwitchEvent";
 		public const string CoilEvent = "CoilEvent";

--- a/Runtime/Gamelogic/VisualScriptingGamelogicEngine.cs
+++ b/Runtime/Gamelogic/VisualScriptingGamelogicEngine.cs
@@ -25,7 +25,7 @@ using VisualPinball.Engine.Game.Engines;
 namespace VisualPinball.Unity.VisualScripting
 {
 	[DisallowMultipleComponent]
-	[AddComponentMenu("Visual Pinball/Game Logic Engine/Visual Scripting Game Logic")]
+	[AddComponentMenu("Visual Pinball/Gamelogic Engine/Visual Scripting Game Logic")]
 	public class VisualScriptingGamelogicEngine : MonoBehaviour, IGamelogicEngine
 	{
 		public string Name => "Visual Scripting Gamelogic Engine";
@@ -51,6 +51,7 @@ namespace VisualPinball.Unity.VisualScripting
 		public event EventHandler<LampColorEventArgs> OnLampColorChanged;
 		public event EventHandler<CoilEventArgs> OnCoilChanged;
 		public event EventHandler<SwitchEventArgs2> OnSwitchChanged;
+		public event EventHandler<EventArgs> OnStarted;
 
 		[NonSerialized] public BallManager BallManager;
 		[NonSerialized] private Player _player;
@@ -59,7 +60,8 @@ namespace VisualPinball.Unity.VisualScripting
 		{
 			_player = player;
 			BallManager = ballManager;
-			EventBus.Trigger(VisualScriptingEventNames.PlayerStartedEvent, EventArgs.Empty);
+
+			OnStarted?.Invoke(this, EventArgs.Empty);
 		}
 
 		public void Switch(string id, bool isClosed)

--- a/Runtime/Gamelogic/VisualScriptingGamelogicEngine.cs
+++ b/Runtime/Gamelogic/VisualScriptingGamelogicEngine.cs
@@ -61,7 +61,7 @@ namespace VisualPinball.Unity.VisualScripting
 			_player = player;
 			BallManager = ballManager;
 
-			OnStarted?.Invoke(this, EventArgs.Empty);
+			EventBus.Trigger(VisualScriptingEventNames.GleStartedEvent, EventArgs.Empty);
 		}
 
 		public void Switch(string id, bool isClosed)

--- a/Runtime/Nodes/GleStartedEventUnit.cs
+++ b/Runtime/Nodes/GleStartedEventUnit.cs
@@ -19,20 +19,15 @@ using Unity.VisualScripting;
 
 namespace VisualPinball.Unity.VisualScripting
 {
-	[UnitTitle("On Player Started Event")]
+	[UnitTitle("On Gamelogic Engine Started Event")]
 	[UnitCategory("Events\\Visual Pinball")]
-	public sealed class PlayerStartedEventUnit : EventUnit<EventArgs>
+	public sealed class GleStartedEventUnit : EventUnit<EventArgs>
 	{
 		protected override bool register => true;
 
 		public override EventHook GetHook(GraphReference reference)
 		{
-			return new EventHook(VisualScriptingEventNames.PlayerStartedEvent);
-		}
-
-		protected override void Definition()
-		{
-			base.Definition();
+			return new EventHook(VisualScriptingEventNames.GleStartedEvent);
 		}
 	}
 }

--- a/Runtime/Nodes/GleStartedEventUnit.cs.meta
+++ b/Runtime/Nodes/GleStartedEventUnit.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 50220fa9400eef54fba36cf0cdabb035
+guid: 1978d4951d07c4cb2bf69173f0be745e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Nodes/GleUnit.cs
+++ b/Runtime/Nodes/GleUnit.cs
@@ -35,10 +35,10 @@ namespace VisualPinball.Unity.VisualScripting
 
 		[DoNotSerialize]
 		protected Player Player;
-
+		
 		protected bool AssertGle(Flow flow)
 		{
-			if (Gle != null) {
+			if (!UnityObjectUtility.IsUnityNull(Gle)) {
 				return true;
 			}
 			Gle = flow.stack.gameObject.GetComponentInParent<IGamelogicEngine>();
@@ -47,7 +47,7 @@ namespace VisualPinball.Unity.VisualScripting
 
 		protected bool AssertPlayer(Flow flow)
 		{
-			if (Player != null) {
+			if (!UnityObjectUtility.IsUnityNull(Player)) {
 				return true;
 			}
 			Player = flow.stack.gameObject.GetComponentInParent<Player>();

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "Visual"
   ],
   "unity": "2021.2",
-  "unityRelease": "7f1",
+  "unityRelease": "8f1",
   "dependencies": {
     "com.unity.visualscripting": "1.7.6",
-    "org.visualpinball.engine.unity": "0.0.1-preview.84"
+    "org.visualpinball.engine.unity": "0.0.1-preview.90"
   },
   "author": "freezy <freezy@vpdb.io>",
   "contributors": [


### PR DESCRIPTION
This PR will need to place after https://github.com/freezy/VisualPinball.Engine/pull/373. We will also need to update the VPE dependency before compiling.

This PR adds support for the new `OnStarted` event.

When working on Rock, we need to initialize our Lamp Relay graph. We can only initialize the graph AFTER the rom has actually started.  `OnPlayerStarted` would happen too soon.