### PR TITLE
Remove internal id from switches, lamps, and coils

### DIFF
--- a/Runtime/Nodes/Lamps/SetLampUnit.cs
+++ b/Runtime/Nodes/Lamps/SetLampUnit.cs
@@ -103,16 +103,16 @@ namespace VisualPinball.Unity.VisualScripting
 				var lampId = flow.GetValue<string>(input);
 				switch (DataType) {
 					case LampDataType.OnOff:
-						Player.SetLamp(lampId, 0, flow.GetValue<bool>(Value) ? LampStatus.On : LampStatus.Off);
+						Player.SetLamp(lampId, flow.GetValue<bool>(Value) ? LampStatus.On : LampStatus.Off);
 						break;
 					case LampDataType.Status:
-						Player.SetLamp(lampId, 0, flow.GetValue<LampStatus>(Value));
+						Player.SetLamp(lampId, flow.GetValue<LampStatus>(Value));
 						break;
 					case LampDataType.Intensity:
-						Player.SetLamp(lampId, 0, flow.GetValue<float>(Value) * GetIntensityMultiplier(lampId));
+						Player.SetLamp(lampId, flow.GetValue<float>(Value) * GetIntensityMultiplier(lampId));
 						break;
 					case LampDataType.Color:
-						Player.SetLamp(lampId, 0, flow.GetValue<UnityEngine.Color>(Value).ToEngineColor());
+						Player.SetLamp(lampId, flow.GetValue<UnityEngine.Color>(Value).ToEngineColor());
 						break;
 					default:
 						throw new ArgumentOutOfRangeException();

--- a/Runtime/Nodes/Lamps/SwitchLampUnit.cs
+++ b/Runtime/Nodes/Lamps/SwitchLampUnit.cs
@@ -139,16 +139,16 @@ namespace VisualPinball.Unity.VisualScripting
 
 				switch (dataType) {
 					case LampDataType.OnOff:
-						Player.SetLamp(lampIdValue.id, 0, flow.GetValue<bool>(value) ? LampStatus.On : LampStatus.Off);
+						Player.SetLamp(lampIdValue.id, flow.GetValue<bool>(value) ? LampStatus.On : LampStatus.Off);
 						break;
 					case LampDataType.Status:
-						Player.SetLamp(lampIdValue.id, 0, flow.GetValue<LampStatus>(value));
+						Player.SetLamp(lampIdValue.id, flow.GetValue<LampStatus>(value));
 						break;
 					case LampDataType.Intensity:
-						Player.SetLamp(lampIdValue.id, 0, flow.GetValue<float>(value) * GetIntensityMultiplier(lampIdValue.id));
+						Player.SetLamp(lampIdValue.id, flow.GetValue<float>(value) * GetIntensityMultiplier(lampIdValue.id));
 						break;
 					case LampDataType.Color:
-						Player.SetLamp(lampIdValue.id, 0, flow.GetValue<UnityEngine.Color>(value).ToEngineColor());
+						Player.SetLamp(lampIdValue.id, flow.GetValue<UnityEngine.Color>(value).ToEngineColor());
 						break;
 					default:
 						throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
This PR is a companion to https://github.com/freezy/VisualPinball.Engine/pull/408

It removes the `InternalId` parameter that is no longer part of switches, lamps, and coils.

To Do:

- [ ] https://github.com/freezy/VisualPinball.Engine/pull/408 merged
- [ ] Bump VPE dependency