### PR TITLE
Add new EMAddPointsUnit and EMResetPointsUnit units

### DIFF
--- a/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
@@ -30,7 +30,8 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 		protected override string DefinedSummary()
 		{
 			return "This node takes an incoming point value and pulses values to that can be used to simulate adding points to a score reel. "
-				+ "\n\nFor example, an incoming point value of 500 will provide 5 pulses of 100.";
+				+ "\n\nFor example, an incoming point value of 500 will provide 5 pulses of 100. "
+				+ "\n\nSingle pulse points (1, 10, 100, 1000, 10000) will be blocked if the score motor is running and Block Points is enabled.";
 		}
 
 		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.Mech(Unity.Editor.IconSize.Large, Unity.Editor.IconColor.Orange));

--- a/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
@@ -29,10 +29,11 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 
 		protected override string DefinedSummary()
 		{
-			return "This node adds points for EMs.";
+			return "This node takes an incoming point value and pulses values to that can be used to simulate adding points to a score reel. "
+				+ "For example, an incoming point value of 500 will provide 5 pulses of 100.";
 		}
 
-		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.PlayerVariable);
+		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.Mech(Unity.Editor.IconSize.Large, Unity.Editor.IconColor.Orange));
 
 		protected override void DefinedPort(IUnitPort port, UnitPortDescription desc)
 		{

--- a/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
@@ -44,6 +44,14 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 					desc.summary = "The total amount of points to add.";
 					break;
 
+				case nameof(EMAddPointsUnit.blockPoints):
+					desc.summary = "Block single pulse points when score motor running.";
+					break;
+
+				case nameof(EMAddPointsUnit.positions):
+					desc.summary = "Score motor positions.";
+					break;
+
 				case nameof(EMAddPointsUnit.duration):
 					desc.summary = "The amount of time (in ms) the score motor runs.";
 					break;

--- a/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
@@ -30,7 +30,7 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 		protected override string DefinedSummary()
 		{
 			return "This node takes an incoming point value and pulses values to that can be used to simulate adding points to a score reel. "
-				+ "For example, an incoming point value of 500 will provide 5 pulses of 100.";
+				+ "\n\nFor example, an incoming point value of 500 will provide 5 pulses of 100.";
 		}
 
 		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.Mech(Unity.Editor.IconSize.Large, Unity.Editor.IconColor.Orange));
@@ -40,6 +40,29 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 			base.DefinedPort(port, desc);
 
 			switch (port.key) {
+				case nameof(EMAddPointsUnit.pointValue):
+					desc.summary = "The total amount of points to add.";
+					break;
+
+				case nameof(EMAddPointsUnit.duration):
+					desc.summary = "The amount of time (in ms) the score motor runs.";
+					break;
+
+				case nameof(EMAddPointsUnit.started):
+					desc.summary = "Triggered when score motor starts.";
+					break;
+
+				case nameof(EMAddPointsUnit.stopped):
+					desc.summary = "Triggered when score motor finishes.";
+					break;
+
+				case nameof(EMAddPointsUnit.pulse):
+					desc.summary = "Triggered during each pulse of the score motor.";
+					break;
+
+				case nameof(EMAddPointsUnit.OutputPointValue):
+					desc.summary = "The current pulses calculated points value that can be used to increment a score value and update a score reel.";
+					break;
 			}
 		}
 	}

--- a/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMAddPointsUnitDescriptor.cs
@@ -1,0 +1,45 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ReSharper disable UnusedType.Global
+
+using Unity.VisualScripting;
+
+namespace VisualPinball.Unity.VisualScripting.Editor
+{
+	[Descriptor(typeof(EMAddPointsUnit))]
+	public class EMAddPointsUnitDescriptor : UnitDescriptor<EMAddPointsUnit>
+	{
+		public EMAddPointsUnitDescriptor(EMAddPointsUnit target) : base(target)
+		{
+		}
+
+		protected override string DefinedSummary()
+		{
+			return "This node adds points for EMs.";
+		}
+
+		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.PlayerVariable);
+
+		protected override void DefinedPort(IUnitPort port, UnitPortDescription desc)
+		{
+			base.DefinedPort(port, desc);
+
+			switch (port.key) {
+			}
+		}
+	}
+}

--- a/Editor/Descriptors/EMAddPointsUnitDescriptor.cs.meta
+++ b/Editor/Descriptors/EMAddPointsUnitDescriptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88349127e95cc4b64bb76e45f82a88e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Descriptors/EMResetPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMResetPointsUnitDescriptor.cs
@@ -30,7 +30,7 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 		protected override string DefinedSummary()
 		{
 			return "This node takes an incoming point value and pulses values to that can be used to simulate the resetting of a score reel. "
-			   + "For example, an incoming point value of 2041 will provide the following pulses: 3052, 4063, 5074, 6085, 7096, 8007, 9008, 0009, 0000";
+			   + "\n\nFor example, an incoming point value of 2041 will provide the following pulses: 3052, 4063, 5074, 6085, 7096, 8007, 9008, 0009, 0000";
 		}
 
 		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.Mech(Unity.Editor.IconSize.Large, Unity.Editor.IconColor.Orange));
@@ -40,6 +40,29 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 			base.DefinedPort(port, desc);
 
 			switch (port.key) {
+				case nameof(EMResetPointsUnit.pointValue):
+					desc.summary = "The starting points value used to seed the reset sequence.";
+					break;
+
+				case nameof(EMResetPointsUnit.duration):
+					desc.summary = "The amount of time (in ms) the score motor runs.";
+					break;
+
+				case nameof(EMResetPointsUnit.started):
+					desc.summary = "Triggered when score motor starts.";
+					break;
+
+				case nameof(EMResetPointsUnit.stopped):
+					desc.summary = "Triggered when score motor finishes.";
+					break;
+
+				case nameof(EMResetPointsUnit.pulse):
+					desc.summary = "Triggered during each pulse of the score motor.";
+					break;
+
+				case nameof(EMResetPointsUnit.OutputPointValue):
+					desc.summary = "The current pulses calculated points value that can be used to update a score reel.";
+					break;
 			}
 		}
 	}

--- a/Editor/Descriptors/EMResetPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMResetPointsUnitDescriptor.cs
@@ -20,11 +20,27 @@ using Unity.VisualScripting;
 
 namespace VisualPinball.Unity.VisualScripting.Editor
 {
-	[Widget(typeof(EMAddPointsUnit))]
-	public sealed class EMAddPointsUnitWidget : GleUnitWidget<EMAddPointsUnit>
+	[Descriptor(typeof(EMResetPointsUnit))]
+	public class EMResetPointsUnitDescriptor : UnitDescriptor<EMResetPointsUnit>
 	{
-		public EMAddPointsUnitWidget(FlowCanvas canvas, EMAddPointsUnit unit) : base(canvas, unit)
+		public EMResetPointsUnitDescriptor(EMResetPointsUnit target) : base(target)
 		{
+		}
+
+		protected override string DefinedSummary()
+		{
+			return "This node takes an incoming point value and pulses values to that can be used to simulate the resetting of a score reel. "
+			   + "For example, an incoming point value of 2041 will provide the following pulses: 3052, 4063, 5074, 6085, 7096, 8007, 9008, 0009, 0000";
+		}
+
+		protected override EditorTexture DefinedIcon() => EditorTexture.Single(Unity.Editor.Icons.Mech(Unity.Editor.IconSize.Large, Unity.Editor.IconColor.Orange));
+
+		protected override void DefinedPort(IUnitPort port, UnitPortDescription desc)
+		{
+			base.DefinedPort(port, desc);
+
+			switch (port.key) {
+			}
 		}
 	}
 }

--- a/Editor/Descriptors/EMResetPointsUnitDescriptor.cs
+++ b/Editor/Descriptors/EMResetPointsUnitDescriptor.cs
@@ -48,6 +48,10 @@ namespace VisualPinball.Unity.VisualScripting.Editor
 					desc.summary = "The amount of time (in ms) the score motor runs.";
 					break;
 
+				case nameof(EMAddPointsUnit.positions):
+					desc.summary = "Score motor positions.";
+					break;
+
 				case nameof(EMResetPointsUnit.started):
 					desc.summary = "Triggered when score motor starts.";
 					break;

--- a/Editor/Descriptors/EMResetPointsUnitDescriptor.cs.meta
+++ b/Editor/Descriptors/EMResetPointsUnitDescriptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5a9f36c94e9543139b6f68c1b0faf5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Widgets/EMAddPointsUnitWidget.cs
+++ b/Editor/Widgets/EMAddPointsUnitWidget.cs
@@ -1,0 +1,33 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ReSharper disable UnusedType.Global
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.VisualScripting;
+
+namespace VisualPinball.Unity.VisualScripting.Editor
+{
+	[Widget(typeof(EMAddPointsUnit))]
+	public sealed class EMAddPointsUnitWidget : GleUnitWidget<EMAddPointsUnit>
+	{
+		public EMAddPointsUnitWidget(FlowCanvas canvas, EMAddPointsUnit unit) : base(canvas, unit)
+		{
+		}
+	}
+}

--- a/Editor/Widgets/EMAddPointsUnitWidget.cs.meta
+++ b/Editor/Widgets/EMAddPointsUnitWidget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6659f99df4fbf4ce59b36703a7385e0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Widgets/EMResetPointsUnitWidget.cs
+++ b/Editor/Widgets/EMResetPointsUnitWidget.cs
@@ -20,10 +20,10 @@ using Unity.VisualScripting;
 
 namespace VisualPinball.Unity.VisualScripting.Editor
 {
-	[Widget(typeof(EMAddPointsUnit))]
-	public sealed class EMAddPointsUnitWidget : GleUnitWidget<EMAddPointsUnit>
+	[Widget(typeof(EMResetPointsUnit))]
+	public sealed class EMResetPointsUnitWidget : GleUnitWidget<EMResetPointsUnit>
 	{
-		public EMAddPointsUnitWidget(FlowCanvas canvas, EMAddPointsUnit unit) : base(canvas, unit)
+		public EMResetPointsUnitWidget(FlowCanvas canvas, EMResetPointsUnit unit) : base(canvas, unit)
 		{
 		}
 	}

--- a/Editor/Widgets/EMResetPointsUnitWidget.cs.meta
+++ b/Editor/Widgets/EMResetPointsUnitWidget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71cb8e09a554f4b1aa91d7d87bea76ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Gamelogic/State.cs
+++ b/Runtime/Gamelogic/State.cs
@@ -61,6 +61,8 @@ namespace VisualPinball.Unity.VisualScripting
 			return _variables[variableId].Get<T>();
 		}
 
+		public bool IsDefined(string variableId) => _variables.ContainsKey(variableId);
+
 		public StateVariable GetVariable(string variableId) => _variables[variableId];
 
 		public object Get(string variableId)

--- a/Runtime/Nodes/EM.meta
+++ b/Runtime/Nodes/EM.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0f219f0a0a654b79862bd68d18a2228
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Nodes/EM/EMAddPointsUnit.cs
+++ b/Runtime/Nodes/EM/EMAddPointsUnit.cs
@@ -49,7 +49,8 @@ namespace VisualPinball.Unity.VisualScripting
 		[DoNotSerialize]
 		public ValueInput pointValue { get; private set; }
 
-		[DoNotSerialize, PortLabel("Point Value"), Inspectable]
+		[DoNotSerialize]
+		[PortLabel("Point Value")]
 		public ValueOutput OutputPointValue { get; private set; }
 
 		private Bool running = false;

--- a/Runtime/Nodes/EM/EMAddPointsUnit.cs
+++ b/Runtime/Nodes/EM/EMAddPointsUnit.cs
@@ -1,0 +1,104 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections;
+using Unity.VisualScripting;
+using UnityEngine;
+
+namespace VisualPinball.Unity.VisualScripting
+{
+	/* 
+	 * Well, I think the node should be an "EM Add Points" node that would accept a "Point Value"  
+	 * and a "Score Motor Value".  It would send a signal directly to the point value's score reel 
+	 * "coil" if the "Score Motor Value" was set to 0.  If the "Score Motor Value" was 1-5 then 
+	 * the "Point Value" along with the "Score Motor Value" would be sent to the Score Motor.  
+	 * The score motor would then send series of pulsed signals to the "point value's" score reel 
+	 * coil equal to the "Score Motor Value."  The reels would have to be set up with a 9's 
+	 * carry over ability (ie 00190 sent a pulse to the 10's coil would have to pulse the 
+	 * 100's coil once to get to 200)  If the score motor is in motion then all scores that occur 
+	 * during this window need to not be scored (per @bord observations today).
+	 */
+
+	[UnitShortTitle("EM Add Points")]
+	[UnitTitle("EM Add Points")]
+	[UnitSurtitle("Gamelogic Engine")]
+	[UnitCategory("Visual Pinball")]
+	public class EMAddPointsUnit : GleUnit
+	{
+		[Serialize, Inspectable, UnitHeaderInspectable("ID")]
+		public DisplayDefinition Display { get; private set; }
+
+		[DoNotSerialize]
+		public ControlInput InputTrigger;
+
+		[DoNotSerialize]
+		[PortLabelHidden]
+		public ControlOutput OutputTrigger;
+
+		[DoNotSerialize]
+		public ControlOutput tick { get; private set; }
+
+		[DoNotSerialize]
+		public ValueInput scoreMotor { get; private set; }
+
+		[DoNotSerialize]
+		public ValueInput pointValue { get; private set; }
+
+		[DoNotSerialize]
+		public ValueInput duration { get; private set; }
+
+		protected override void Definition()
+		{
+			InputTrigger = ControlInputCoroutine(nameof(InputTrigger), Process);
+			OutputTrigger = ControlOutput(nameof(OutputTrigger));
+
+			tick = ControlOutput(nameof(tick));
+
+			pointValue = ValueInput(nameof(pointValue), 0);
+			scoreMotor = ValueInput(nameof(scoreMotor), 0);
+
+			duration = ValueInput(nameof(duration), 0f);
+		}
+
+		private IEnumerator Process(Flow flow)
+		{
+			if (!AssertGle(flow))
+			{
+				Debug.LogError("Cannot find GLE.");
+				yield return OutputTrigger;
+			}
+
+			if (!AssertPlayer(flow))
+			{
+				Debug.LogError("Cannot find player.");
+				yield return OutputTrigger;
+			}
+
+			var seconds = flow.GetValue<float>(this.duration);
+
+			for (int loop = 0; loop < 5; loop++)
+			{
+				yield return new WaitForSeconds(seconds);
+
+				yield return tick;
+
+				Debug.Log($"ITERATION LOOP {loop}");
+			}
+
+			yield return OutputTrigger;
+		}
+	}
+}

--- a/Runtime/Nodes/EM/EMAddPointsUnit.cs.meta
+++ b/Runtime/Nodes/EM/EMAddPointsUnit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d673fe77022c74cdf8426b744e12cf9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Nodes/EM/EMResetPointsUnit.cs
+++ b/Runtime/Nodes/EM/EMResetPointsUnit.cs
@@ -49,7 +49,8 @@ namespace VisualPinball.Unity.VisualScripting
 		[DoNotSerialize]
 		public ValueInput pointValue { get; private set; }
 
-		[DoNotSerialize, PortLabel("Point Value"), Inspectable]
+		[DoNotSerialize]
+		[PortLabel("Point Value")]
 		public ValueOutput OutputPointValue { get; private set; }
 
 		private Bool running = false;

--- a/Runtime/Nodes/EM/EMResetPointsUnit.cs.meta
+++ b/Runtime/Nodes/EM/EMResetPointsUnit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37d591d7c9d694b89a42a1ff9ce2545f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds two new units `EMAddPointsUnit` and `EMResetPointsUnit` that was designed with the assistance of @scottacus64.

## `EMAddPointsUnit`

<img width="899" alt="Screen Shot 2022-07-01 at 7 52 44 AM" src="https://user-images.githubusercontent.com/1197137/176889718-0acff563-bf9e-468d-a530-19fbae982d98.png">

This unit accepts Point Value, Positions, Duration (in ms), and Block Points values. 

Point Value is used to calculate the amount of points to add for each pulse of the unit.

Examples:

Score 50 points while the score motor is not running:
- Start the score motor
- Wait for the delay and trigger a pulse with 10 points
- Wait for the delay and trigger a pulse with 10 points
- Wait for the delay and trigger a pulse with 10 points
- Wait for the delay and trigger a pulse with 10 points
- Wait for the delay and trigger a pulse with 10 points
- Wait for the delay and trigger a pulse with 0 points
- Stop the score motor

Score 50 points while the score motor is running:
- Do nothing 

Score 100 points while the score motor is not running:
- Trigger a pulse with 100 points

Score 100 points while the score motor is running and Block Points disabled:
- Trigger a pulse with 100 points

Score 100 points while the score motor is running and Block Points enabled:
- Do nothing

The Duration and Positions are used to calculate delays. 

![score_motor](https://user-images.githubusercontent.com/1197137/175313981-04d34b73-a10c-4301-83bd-de89ca56fb35.png)

The examples were based on a Gottlieb score motor with 6 positions.

## `EMResetPointsUnit`

<img width="898" alt="Screen Shot 2022-07-01 at 7 52 59 AM" src="https://user-images.githubusercontent.com/1197137/176889805-31f3f4ba-9ffe-4843-9d9f-5e6b7f3e3868.png">

This unit accepts Point Value, Positions, and Duration (in ms) values. It can be used to simulate the values of a resetting score reel. 

Point Value is used as a starting point. For each pulse, all digits are incremented until they reach 0.

Example:

Score reel shows 2041 points:
- Start the score motor
- Wait for the delay and trigger a pulse with 3052 points
- Wait for the delay and trigger a pulse with 4063 points
- Wait for the delay and trigger a pulse with 5074 points
- Wait for the delay and trigger a pulse with 6085 points
- Wait for the delay and trigger a pulse with 7096 points
- Wait for the delay and trigger a pulse with 8007 points
- Wait for the delay and trigger a pulse with 9008 points
- Wait for the delay and trigger a pulse with 9 points
- Wait for the delay and trigger a pulse with 0 points
- Wait for the delay and trigger a pulse with 0 points
- Wait for the delay and trigger a pulse with 0 points
- Wait for the delay and trigger a pulse with 0 points
- Stop the score motor

This example is based on a Gottlieb score motor with 6 positions.