### PR TITLE
Enhance SwitchLampUnit to accept comparison type

### DIFF
--- a/Editor/Inspectors/AttributedEnumInspector.cs
+++ b/Editor/Inspectors/AttributedEnumInspector.cs
@@ -1,0 +1,89 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Unity.VisualScripting;
+using UnityEditor;
+using UnityEngine;
+
+namespace VisualPinball.Unity.VisualScripting.Editor
+{
+    public abstract class AttributedEnumInspector<TEnum> : Inspector
+    {
+        private List<TEnum> Enums;
+        private string[] EnumDescriptions;
+   
+        public AttributedEnumInspector(Metadata metadata) : base(metadata) {
+        }
+
+        public override void Initialize()
+        {
+            Enums = Enum.GetValues(typeof(TEnum)).Cast<TEnum>().ToList();
+            EnumDescriptions = Enum.GetValues(typeof(TEnum)).Cast<TEnum>().Select(x => GetEnumDescription(x)).ToArray();
+
+            metadata.instantiate = true;
+
+            base.Initialize();
+        }
+
+        protected override float GetHeight(float width, GUIContent label)
+        {
+            return HeightWithLabel(metadata, width, EditorGUIUtility.singleLineHeight, label);
+        }
+
+        protected override void OnGUI(Rect position, GUIContent label)
+        {
+            position = BeginLabeledBlock(metadata, position, label);
+
+            var fieldPosition = new Rect
+                (
+                position.x,
+                position.y,
+                position.width,
+                EditorGUIUtility.singleLineHeight
+                );
+
+            var index = Enums.FindIndex(c => c.Equals(metadata.value));
+            var newIndex = EditorGUI.Popup(fieldPosition, index, EnumDescriptions);
+
+            if (EndBlock(metadata))
+			{
+                metadata.RecordUndo();
+                metadata.value = Enums[newIndex];
+            }
+        }
+
+        public override float GetAdaptiveWidth()
+        {
+            return Mathf.Max(18, EditorStyles.popup.CalcSize(new GUIContent(GetEnumDescription((TEnum)metadata.value))).x);
+        }
+
+        private string GetEnumDescription(TEnum value)
+        {
+            FieldInfo field = value.GetType().GetField(value.ToString());
+
+            DescriptionAttribute attribute
+                    = Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute))
+                        as DescriptionAttribute;
+
+            return (attribute == null ? value.ToString() : attribute.Description).Replace('/', '\u2215');
+        }
+    }
+}

--- a/Editor/Inspectors/AttributedEnumInspector.cs.meta
+++ b/Editor/Inspectors/AttributedEnumInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c60df3d32f18d4d3e9019e2592b52ba9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/CompareTypeInspector.cs
+++ b/Editor/Inspectors/CompareTypeInspector.cs
@@ -14,95 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
 using Unity.VisualScripting;
-using UnityEditor;
-using UnityEngine;
 
 namespace VisualPinball.Unity.VisualScripting.Editor
 {
     [Inspector(typeof(CompareType))]
-    public class CompareTypeInspector : Inspector
+    public class CompareTypeInspector : AttributedEnumInspector<CompareType>
     {
-        private List<CompareType> CompareTypes = Enum.GetValues(typeof(CompareType)).Cast<CompareType>().ToList();
-        private string[] CompareTypeDescriptions = Enum.GetValues(typeof(CompareType)).Cast<CompareType>().Select(x => GetEnumDescription(x)).ToArray();
-        
-        public CompareTypeInspector(Metadata metadata) : base(metadata) {
-        }
-
-        public override void Initialize()
+        public CompareTypeInspector(Metadata metadata) : base(metadata)
         {
-            metadata.instantiate = true;
-
-            base.Initialize();
         }
-
-        protected override float GetHeight(float width, GUIContent label)
-        {
-            return HeightWithLabel(metadata, width, EditorGUIUtility.singleLineHeight, label);
-        }
-
-        protected override void OnGUI(Rect position, GUIContent label)
-        {
-            position = BeginLabeledBlock(metadata, position, label);
-
-            var fieldPosition = new Rect
-                (
-                position.x,
-                position.y,
-                position.width,
-                EditorGUIUtility.singleLineHeight
-                );
-
-            var index = CompareTypes.FindIndex(c => c == (CompareType)metadata.value);
-            var newIndex = EditorGUI.Popup(fieldPosition, index, CompareTypeDescriptions);
-
-            if (EndBlock(metadata))
-			{
-                metadata.RecordUndo();
-                metadata.value = CompareTypes[newIndex];
-            }
-        }
-
-        public override float GetAdaptiveWidth()
-        {
-            return Mathf.Max(18, EditorStyles.popup.CalcSize(new GUIContent(GetEnumDescription((CompareType)metadata.value))).x + Styles.popup.fixedWidth);
-        }
-
-        private static string GetEnumDescription(Enum value)
-        {
-            FieldInfo field = value.GetType().GetField(value.ToString());
-
-            DescriptionAttribute attribute
-                    = Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute))
-                        as DescriptionAttribute;
-
-            return (attribute == null ? value.ToString() : attribute.Description).Replace('/', '\u2215');
-        }
-    }
-
-    public static class Styles
-    {
-        static Styles()
-        {
-            popup = new GUIStyle("TextFieldDropDown");
-            popup.fixedWidth = 10;
-            popup.clipping = TextClipping.Clip;
-            popup.normal.textColor = ColorPalette.transparent;
-            popup.active.textColor = ColorPalette.transparent;
-            popup.hover.textColor = ColorPalette.transparent;
-            popup.focused.textColor = ColorPalette.transparent;
-            popup.onNormal.textColor = ColorPalette.transparent;
-            popup.onActive.textColor = ColorPalette.transparent;
-            popup.onHover.textColor = ColorPalette.transparent;
-            popup.onFocused.textColor = ColorPalette.transparent;
-        }
-
-        public static readonly GUIStyle textField;
-        public static readonly GUIStyle popup;
     }
 }

--- a/Editor/Inspectors/CompareTypeInspector.cs
+++ b/Editor/Inspectors/CompareTypeInspector.cs
@@ -1,0 +1,108 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Unity.VisualScripting;
+using UnityEditor;
+using UnityEngine;
+
+namespace VisualPinball.Unity.VisualScripting.Editor
+{
+    [Inspector(typeof(CompareType))]
+    public class CompareTypeInspector : Inspector
+    {
+        private List<CompareType> CompareTypes = Enum.GetValues(typeof(CompareType)).Cast<CompareType>().ToList();
+        private string[] CompareTypeDescriptions = Enum.GetValues(typeof(CompareType)).Cast<CompareType>().Select(x => GetEnumDescription(x)).ToArray();
+        
+        public CompareTypeInspector(Metadata metadata) : base(metadata) {
+        }
+
+        public override void Initialize()
+        {
+            metadata.instantiate = true;
+
+            base.Initialize();
+        }
+
+        protected override float GetHeight(float width, GUIContent label)
+        {
+            return HeightWithLabel(metadata, width, EditorGUIUtility.singleLineHeight, label);
+        }
+
+        protected override void OnGUI(Rect position, GUIContent label)
+        {
+            position = BeginLabeledBlock(metadata, position, label);
+
+            var fieldPosition = new Rect
+                (
+                position.x,
+                position.y,
+                position.width,
+                EditorGUIUtility.singleLineHeight
+                );
+
+            var index = CompareTypes.FindIndex(c => c == (CompareType)metadata.value);
+            var newIndex = EditorGUI.Popup(fieldPosition, index, CompareTypeDescriptions);
+
+            if (EndBlock(metadata))
+			{
+                metadata.RecordUndo();
+                metadata.value = CompareTypes[newIndex];
+            }
+        }
+
+        public override float GetAdaptiveWidth()
+        {
+            return Mathf.Max(18, EditorStyles.popup.CalcSize(new GUIContent(GetEnumDescription((CompareType)metadata.value))).x + Styles.popup.fixedWidth);
+        }
+
+        private static string GetEnumDescription(Enum value)
+        {
+            FieldInfo field = value.GetType().GetField(value.ToString());
+
+            DescriptionAttribute attribute
+                    = Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute))
+                        as DescriptionAttribute;
+
+            return (attribute == null ? value.ToString() : attribute.Description).Replace('/', '\u2215');
+        }
+    }
+
+    public static class Styles
+    {
+        static Styles()
+        {
+            popup = new GUIStyle("TextFieldDropDown");
+            popup.fixedWidth = 10;
+            popup.clipping = TextClipping.Clip;
+            popup.normal.textColor = ColorPalette.transparent;
+            popup.active.textColor = ColorPalette.transparent;
+            popup.hover.textColor = ColorPalette.transparent;
+            popup.focused.textColor = ColorPalette.transparent;
+            popup.onNormal.textColor = ColorPalette.transparent;
+            popup.onActive.textColor = ColorPalette.transparent;
+            popup.onHover.textColor = ColorPalette.transparent;
+            popup.onFocused.textColor = ColorPalette.transparent;
+        }
+
+        public static readonly GUIStyle textField;
+        public static readonly GUIStyle popup;
+    }
+}

--- a/Editor/Inspectors/CompareTypeInspector.cs.meta
+++ b/Editor/Inspectors/CompareTypeInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac7985d65cfa449d389e96d71b1ac8da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/LampDataTypeInspector.cs
+++ b/Editor/Inspectors/LampDataTypeInspector.cs
@@ -14,17 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System.ComponentModel;
+using Unity.VisualScripting;
 
-namespace VisualPinball.Unity.VisualScripting
+namespace VisualPinball.Unity.VisualScripting.Editor
 {
-	public enum LampDataType
-	{
-		[Description("On/Off")]
-		OnOff,
-
-		Status,
-		Intensity,
-		Color,
-	}
+    [Inspector(typeof(LampDataType))]
+    public class LampDataTypeInspector : AttributedEnumInspector<LampDataType>
+    {
+        public LampDataTypeInspector(Metadata metadata) : base(metadata)
+        {
+        }
+    }
 }

--- a/Editor/Inspectors/LampDataTypeInspector.cs.meta
+++ b/Editor/Inspectors/LampDataTypeInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3c891d4e51ab4d26aec2424438cc7d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Nodes/Lamps/SwitchLampUnit.cs
+++ b/Runtime/Nodes/Lamps/SwitchLampUnit.cs
@@ -158,7 +158,7 @@ namespace VisualPinball.Unity.VisualScripting
 						break;
 
 					case CompareType.LessThanEqual:
-						match = lampIdValue.value < sourceValue;
+						match = lampIdValue.value <= sourceValue;
 						break;
 
 					default:

--- a/Runtime/Nodes/Lamps/SwitchLampUnit.cs
+++ b/Runtime/Nodes/Lamps/SwitchLampUnit.cs
@@ -37,6 +37,9 @@ namespace VisualPinball.Unity.VisualScripting
 		[Serialize, Inspectable, UnitHeaderInspectable("Non Match")]
 		public LampDataType NonMatchDataType { get; set; }
 
+		[Serialize, Inspectable, UnitHeaderInspectable("Value Compare")]
+		public CompareType ValueCompareType { get; set; }
+
 		[DoNotSerialize]
 		[Inspectable, UnitHeaderInspectable("Lamp IDs")]
 		public int inputCount
@@ -134,8 +137,37 @@ namespace VisualPinball.Unity.VisualScripting
 
 				var lampIdValue = _lampIdValueCache[json.GetHashCode()];
 
-				var dataType = lampIdValue.value == sourceValue ? MatchDataType : NonMatchDataType;
-				var value = lampIdValue.value == sourceValue ? Match : NonMatch;
+				var match = false;
+
+				switch(ValueCompareType)
+				{
+					case CompareType.NotEqual:
+						match = lampIdValue.value != sourceValue;
+						break;
+
+					case CompareType.GreaterThan:
+						match = lampIdValue.value > sourceValue;
+						break;
+
+					case CompareType.GreaterThanEqual:
+						match = lampIdValue.value >= sourceValue;
+						break;
+
+					case CompareType.LessThan:
+						match = lampIdValue.value < sourceValue;
+						break;
+
+					case CompareType.LessThanEqual:
+						match = lampIdValue.value < sourceValue;
+						break;
+
+					default:
+						match = lampIdValue.value == sourceValue;
+						break;
+				}
+
+				var dataType = match ? MatchDataType : NonMatchDataType;
+				var value = match ? Match : NonMatch;
 
 				switch (dataType) {
 					case LampDataType.OnOff:

--- a/Runtime/Nodes/Logic.meta
+++ b/Runtime/Nodes/Logic.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73192e7aa6c1d4d6fb9f28787a6dc0df
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Nodes/Logic/CompareType.cs
+++ b/Runtime/Nodes/Logic/CompareType.cs
@@ -1,0 +1,41 @@
+﻿// Visual Pinball Engine
+// Copyright (C) 2022 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.ComponentModel;
+
+namespace VisualPinball.Unity.VisualScripting
+{
+	public enum CompareType
+	{
+        [Description("=")]
+        Equal,
+
+        [Description("\u2260")]
+        NotEqual,
+
+        [Description("<")]
+        LessThan,
+
+        [Description("\u2264")]
+        LessThanEqual,
+
+        [Description(">")]
+        GreaterThan,
+
+        [Description("\u2265")]
+        GreaterThanEqual
+    }
+}

--- a/Runtime/Nodes/Logic/CompareType.cs.meta
+++ b/Runtime/Nodes/Logic/CompareType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db84bb9bc867b4f5ba03a14e54abc2ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR updates the `SwitchLampUnit` to allow for a comparison type to be used when evaluating a match. Prior to this, matches occurred when the `Value` was equal to the `Source Value`.

This change allows incrementing variables to be used to turn on / off multiple lamps:

<img width="338" alt="Screen Shot 2022-06-23 at 10 02 32 AM" src="https://user-images.githubusercontent.com/1197137/175318248-e7d00d5b-ce7f-49dc-bf62-ec842a60d4c0.png">

To support the `ComparisonType` enum displaying symbols instead of the enum value as a string, we created a new `AttributedEnumInspector`. This allows for overriding the displayed text with the `Description` attribute.

This new `AttributedEnumInspector` was then reused for the `LampDataTypeInspector`:

```
	public enum LampDataType
	{
		[Description("On/Off")]
		OnOff,
```		

When looking at the following image, we see the drop down now shows `On / Off` instead of `On Off`:

<img width="315" alt="Screen Shot 2022-06-23 at 10 10 44 AM" src="https://user-images.githubusercontent.com/1197137/175319906-6b3289b0-26fa-4c01-9f1c-4fa50581798c.png">
